### PR TITLE
Removes maven-shade-plugin to prevent fat jar packaging Fixes issue #45

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This is only a development fork of the Pandomium project. Find the original project and its releases https://github.com/dzikoysk/Pandomium
+
 # Pandomium [![Build Status](https://travis-ci.org/dzikoysk/Pandomium.svg?branch=master)](https://travis-ci.org/Panda-Programming-Language/Pandomium) [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/dzikoysk/Pandomium.svg)](http://isitmaintained.com/project/dzikoysk/Pandomium "Average time to resolve an issue")
 Pandomium is the JCEF (Java Chromium Embedded Framework) implementation dedicated for the maven projects 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-This is only a development fork of the Pandomium project. Find the original project and its releases https://github.com/dzikoysk/Pandomium
-
 # Pandomium [![Build Status](https://travis-ci.org/dzikoysk/Pandomium.svg?branch=master)](https://travis-ci.org/Panda-Programming-Language/Pandomium) [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/dzikoysk/Pandomium.svg)](http://isitmaintained.com/project/dzikoysk/Pandomium "Average time to resolve an issue")
 Pandomium is the JCEF (Java Chromium Embedded Framework) implementation dedicated for the maven projects 
 

--- a/pandomium/pom.xml
+++ b/pandomium/pom.xml
@@ -67,18 +67,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4.1</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -95,18 +95,6 @@
         <defaultGoal>clean install</defaultGoal>
         <plugins>
             <plugin>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4.1</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <dependencies>


### PR DESCRIPTION
In issue #45 I described that the FAT jar packaging causes problems by overwriting my logging implementation. This is because I had no granular control of which third party dependencies are used in my application. 

Removal of the shade plugin allows me now to configure the dependencies and exclude the extra logging dependencies which allows my logging to work once again. 